### PR TITLE
updating bnd

### DIFF
--- a/dev/com.ibm.ws.ssl/bnd.bnd
+++ b/dev/com.ibm.ws.ssl/bnd.bnd
@@ -33,7 +33,8 @@ Export-Package: com.ibm.websphere.ssl*;provide:=true, \
     com.ibm.wsspi.ssl;provide:=true, \
     com.ibm.ws.ssl;provide:=true, \
     com.ibm.ws.ssl.optional;provide:=true, \
-    com.ibm.ws.ssl.provider;provide:=true
+    com.ibm.ws.ssl.provider;provide:=true, \
+    com.ibm.ws.ssl.config;version=1.0
     
 Import-Package: \
 	com.ibm.crypto.pkcs11impl.provider;resolution:=optional, \


### PR DESCRIPTION
fixing build break issue
```java.lang.NoClassDefFoundError: com/ibm/ws/ssl/config/WSKeyStore
	at com.ibm.ws.collective.security.CollectiveDNUtil.buildSubjectAltNames(CollectiveDNUtil.java:424)
	at com.ibm.ws.collective.utility.tasks.CreateTask.handleTask(CreateTask.java:311)
	at com.ibm.ws.collective.utility.CollectiveUtility.runProgram(CollectiveUtility.java:140)
	at com.ibm.ws.collective.utility.CollectiveUtility.main(CollectiveUtility.java:207)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at com.ibm.ws.kernel.boot.cmdline.UtilityMain.internal_main(UtilityMain.java:175)
	at com.ibm.ws.kernel.boot.cmdline.UtilityMain.main(UtilityMain.java:55)
	at com.ibm.ws.kernel.boot.cmdline.Main.main(Main.java:54)
Caused by: java.lang.ClassNotFoundException: com.ibm.ws.ssl.config.WSKeyStore
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593)
	at com.ibm.ws.kernel.boot.cmdline.PackageDelegateClassLoader.loadClass(PackageDelegateClassLoader.java:57)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)```